### PR TITLE
feat: release pipeline for tagging and publishing

### DIFF
--- a/.czrc
+++ b/.czrc
@@ -1,0 +1,3 @@
+{
+  "path": "cz-conventional-changelog"
+}

--- a/.github/workflows/pypi.yaml
+++ b/.github/workflows/pypi.yaml
@@ -1,0 +1,32 @@
+name: PyPI
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  publish:
+
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Setup Python
+        uses: actions/setup-python@v2
+
+      - run: python -m pip install --upgrade pip
+
+      - run: pip install -r requirements-dev.txt
+
+      - run: make clean
+
+      - name: Run twine
+        env:
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.RABE_PYPI_TOKEN }}
+          TWINE_NON_INTERACTIVE: true
+        run: |
+          python setup.py sdist bdist_wheel
+          twine upload dist/*

--- a/.github/workflows/semantic-release.yaml
+++ b/.github/workflows/semantic-release.yaml
@@ -1,0 +1,22 @@
+name: Run semantic-release
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  semantic-release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2.4.0
+        with:
+          fetch-depth: 0
+
+      - name: Run go-semantic-release
+        id: semrel
+        uses: go-semantic-release/action@v1
+        with:
+          github-token: ${{ secrets.RABE_ITREAKTION_GITHUB_TOKEN }}
+          allow-initial-development-versions: true

--- a/.gitignore
+++ b/.gitignore
@@ -62,6 +62,7 @@ instance/
 
 # Sphinx documentation
 docs/_build/
+docs/api/
 
 # PyBuilder
 target/

--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,14 @@ docs: api-doc ## Generate documentation.
 api-doc: ## Generate API docs using Sphinx.
 	sphinx-apidoc -M -f -o docs/api nowplaypadgen
 
+.PHONY: clean
+clean:  ## Clean dist
+	rm -rf dist/ build/ .eggs/
+
+.PHONY: dist
+dist: clean ## Build dist
+	python setup.py sdist bdist_wheel
+
 .PHONY: help
 help: ## Display this help.
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'

--- a/README.md
+++ b/README.md
@@ -2,6 +2,37 @@
 
 DAB+ now playing PAD (DLS+ and MOT SLS) generator
 
+## Release Management
+
+The CI/CD setup uses semantic commit messages following the [conventional commits standard](https://www.conventionalcommits.org/en/v1.0.0/).
+There is a GitHub Action in [.github/workflows/semantic-release.yaml](./.github/workflows/semantic-release.yaml)
+that uses [go-semantic-commit](https://go-semantic-release.xyz/) to create new
+releases.
+
+The commit message should be structured as follows:
+
+```
+<type>[optional scope]: <description>
+
+[optional body]
+
+[optional footer(s)]
+```
+
+The commit contains the following structural elements, to communicate intent to the consumers of your library:
+
+1. **fix:** a commit of the type `fix` patches gets released with a PATCH version bump
+1. **feat:** a commit of the type `feat` gets released as a MINOR version bump
+1. **BREAKING CHANGE:** a commit that has a footer `BREAKING CHANGE:` gets released as a MAJOR version bump
+1. types other than `fix:` and `feat:` are allowed and don't trigger a release
+
+If a commit does not contain a conventional commit style message you can fix
+it during the squash and merge operation on the PR.
+
+Once a commit has landed on the `main` branch a release will be created and automatically published to [pypi](https://pypi.org/)
+using the GitHub Action in [.github/workflows/pypi.yaml](./.github/workflows/pypi.yaml) which uses [twine](https://twine.readthedocs.io/)
+to publish the package to pypi.
+
 ## Development
 
 ### Install requirements

--- a/nowplaypadgen/__init__.py
+++ b/nowplaypadgen/__init__.py
@@ -1,3 +1,1 @@
 """DAB+ now playing PAD (DLS+ and MOT SLS generator)."""
-
-__version__ = "0.1.0"

--- a/nowplaypadgenctl/__main__.py
+++ b/nowplaypadgenctl/__main__.py
@@ -1,16 +1,20 @@
-"""Main entrypoint for interacting with nowplaypadgen."""
+"""Command line tool to interact with nowplaypadgen."""
 
 import argparse
 import logging
 import os
 import sys
+from distutils.core import run_setup
 
-import nowplaypadgen
+
+def get_version() -> str:
+    """Get version from setup.py."""
+    return run_setup("./setup.py", stop_after="init").version
 
 
 def parse_arguments():  # pragma: no cover
     """Parse arguments passed by user."""
-    parser = argparse.ArgumentParser(description=nowplaypadgen.__doc__)
+    parser = argparse.ArgumentParser(description=__doc__)
 
     default_config = os.path.dirname(__file__) + "../nowplaypadgen.conf"
 
@@ -30,11 +34,12 @@ def parse_arguments():  # pragma: no cover
         "-t", "--title", action="store", help="The title of the currently playing track"
     )
 
+    version = get_version()
     parser.add_argument(
         "-v",
         "--version",
         action="version",
-        version=nowplaypadgen.__version__,
+        version=f"%(prog)s {version}",
         help="Display the version",
     )
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,12 +1,12 @@
 -r requirements.txt
 black==21.12b0
-factory-boy==3.2.1
 flake8==4.0.1
 flake8-debugger==4.0.0
 flake8-docstrings==1.6.0
 flake8-isort==4.1.1
 flake8-string-format==0.3.0
 flake8-tuple==0.4.1
+groundwork-sphinx-theme==1.1.1
 isort==5.10.1
 mock==4.0.3
 pytest==6.2.5
@@ -14,4 +14,4 @@ pytest-cov==3.0.0
 pytest-env==0.6.2
 pytest-pylint==0.18.0
 sphinx==4.3.2
-groundwork-sphinx-theme==1.1.1
+twine==3.7.1

--- a/setup.py
+++ b/setup.py
@@ -1,40 +1,25 @@
 """Set up nowplaypadgen."""
 
-import os
-import re
-
 from setuptools import find_packages, setup
 
 with open("requirements.txt", encoding="utf-8") as f:
     requirements = f.read().splitlines()
 
 
-def get_version():
-    """Get version from main module."""
-    version_file = os.path.join("nowplaypadgen", "__init__.py")
-    initfile_lines = open(version_file, "rt", encoding="utf-8").readlines()
-    for line in initfile_lines:
-        matches = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]", line, re.M)
-        if matches:
-            return matches.group(1)
-    raise RuntimeError(f"Unable to find version string in {version_file}.")
-
-
 setup(
     name="nowplaypadgen",
-    version=get_version(),
     description="DAB+ now playing PAD (DLS+ and MOT SLS generator)",
     url="https://github.com/radiorabe/nowplaypadgen",
-    author="Christian Affolter",
-    author_email="c.affolter@purplehaze.ch",
+    author="RaBe IT-Reaktion",
+    author_email="it@rabe.ch",
     license="AGPL-3",
-    packages=find_packages(),
+    packages=find_packages(exclude=("tests",)),
+    version_config={"starting_version": "0.1.0"},
+    setup_requires=["setuptools-git-versioning"],
     install_requires=requirements,
-    include_package_data=True,
-    entry_points={"console_scripts": ["nowplay-padgen = nowplaypadgen.__main__:main"]},
-    zip_safe=False,
+    entry_points={"console_scripts": ["nowplaypadgenctl = nowplaypadgenctl:main"]},
     classifiers=[
         "Development Status :: 3 - Alpha",
-        "License :: OSI Approved :: AGPL License",
+        "License :: OSI Approved :: GNU Affero General Public License v3",
     ],
 )


### PR DESCRIPTION
* add semantic releasing based on conventional-commit and go-semantic-release
* add publishing to pypi using twine
* move cli interface to nowplaypadgenctl module
* do not publish nowplaypadgenctl cli module (it's wip)
* Fixes #3 