### PR TITLE
feat: expose code and category as property in DLPlusContentType

### DIFF
--- a/nowplaypadgen/dlplus.py
+++ b/nowplaypadgen/dlplus.py
@@ -632,11 +632,11 @@ class DLPlusMessage:
 
         >>> tags = message.get_dlp_tags()
         >>> long = tags['STATIONNAME.LONG']
-        >>> f"{long} {long.start} {long.length}"
-        'STATIONNAME.LONG 0 10'
+        >>> f"{long}: {long.code} {long.start} {long.length}"
+        'STATIONNAME.LONG: 32 0 10'
         >>> short = tags['STATIONNAME.SHORT']
-        >>> f"{short} {short.start} {short.length}"
-        'STATIONNAME.SHORT 6 4'
+        >>> f"{short}: {short.code} {short.start} {short.length}"
+        'STATIONNAME.SHORT: 31 6 4'
 
         :param str format_string: The DL Plus message string format with content
                                   type replacement patterns in curly braces
@@ -718,25 +718,29 @@ class DLPlusContentType:
         #: Store content_type info for later lookups
         self._content_type: _ContentType = CONTENT_TYPES[content_type]
 
-    def get_code(self) -> int:
+    @property
+    def code(self) -> int:
         """Get the content type code.
 
         Returns the content type code according to ETSI TS 102 980, Annex A
         (List of DL Plus content types), Table A.1.
 
-        :return: content type code
+        :return: The content type code
         """
-
         return self._content_type["code"]
 
-    def get_category(self) -> str:
+    @property
+    def category(self) -> str:
         """Get the content type category.
 
         Returns the content type category according to ETSI TS 102 980, Annex A
         (List of DL Plus content types), Table A.1.
 
-        :return: category string
-        :rtype: str
+        >>> content_type = DLPlusContentType("ITEM.ARTIST")
+        >>> content_type.category
+        'Item'
+
+        :return: The content type category string
         """
         return self._content_type["category"]
 
@@ -858,7 +862,7 @@ class DLPlusTag(DLPlusContentType):
 
     You can access the tags low-level DLS code point
 
-    >>> tag.get_code()
+    >>> tag.code
     1
     """
 

--- a/tests/test_dlplus_content_type.py
+++ b/tests/test_dlplus_content_type.py
@@ -26,7 +26,7 @@ def test_content_type_category():
 
     for content_type, category in content_types_to_categories:
         dlp_content_type = DLPlusContentType(content_type)
-        assert dlp_content_type.get_category() == category
+        assert dlp_content_type.category == category
 
 
 def test_content_type_code():
@@ -43,7 +43,7 @@ def test_content_type_code():
 
     for content_type, code in content_types_to_codes:
         dlp_content_type = DLPlusContentType(content_type)
-        assert dlp_content_type.get_code() == code
+        assert dlp_content_type.code == code
 
 
 def test_invalid_content_type():


### PR DESCRIPTION
The content type code should be exposed as property. this will aid in implementing #18 